### PR TITLE
Fix Pie Chart Won't Show if 100%

### DIFF
--- a/jsrf/src/js/razorcharts/renderers/column.js
+++ b/jsrf/src/js/razorcharts/renderers/column.js
@@ -1,4 +1,4 @@
-define(['razorcharts/utils/colorutils', 'vendor/lodash'], function(colorUtils, _) {
+define(['razorcharts/utils/colorUtils', 'vendor/lodash'], function(colorUtils, _) {
     var ColumnChart = function() {
         // Constants
         var SERIES_PADDING = 0.4,

--- a/jsrf/src/js/razorcharts/renderers/pie.js
+++ b/jsrf/src/js/razorcharts/renderers/pie.js
@@ -390,6 +390,9 @@ define(['razorcharts/utils/timer', 'razorcharts/utils/pathgen', 'razorcharts/uti
         };
 
         var slicePath = function(cx, cy, startAngle, endAngle, innerRadius, outerRadius){
+            // full circle angle is impossible in SVG
+            if (endAngle % 360 == 0)
+                endAngle -= 0.01;
             var cut = Math.abs(startAngle - endAngle) > 180 ? 1 : 0;
             var startX  = cx + innerRadius * Math.cos(Math.PI * startAngle / 180),
                 startY = cy + innerRadius * Math.sin(Math.PI * startAngle / 180),


### PR DESCRIPTION
Fixes #8 by setting endAngle to less than 360 degrees. SVG Path Arc behavior is it won't show 360 degrees arc (full circle). So the solution is to make it into 359.99 degrees.

Minor: fixes require in linux/*nix for colorutils --> colorUtils (case sensitive)