### PR TITLE
Added function to reset breadcrumbs on a drillstep chart

### DIFF
--- a/jsrf/src/js/components/chartcomponent.js
+++ b/jsrf/src/js/components/chartcomponent.js
@@ -186,7 +186,10 @@ define([
         pro.requestRedraw();
         pro.aspect.revoke('series');
       },
-
+      resetBreadCrumbs: function() { 
+        drillLabelList = []; 
+        currentDrillDownStep = 0; 
+      },
       addDrillStep: function(cb) {
         pro.isDrillDownable = true;
         drillDownSteps.push(cb);


### PR DESCRIPTION
The function is resetBreadCrumbs and takes no parameters. It resets the drillstep count and the list.
