### PR TITLE
Fixed chart display for close-to-zero data

### DIFF
--- a/jsrf/src/js/razorcharts/utils/graphutils.js
+++ b/jsrf/src/js/razorcharts/utils/graphutils.js
@@ -7,7 +7,15 @@ define(['vendor/lodash'], function (_) {
      * @return Object output domain
      */
     prettyDomain: function (min, max, dontExtend) {
-
+      var minBoundaryAbs = 0.11;
+      var minAbs = Math.abs(min);
+      var maxAbs = Math.abs(max);
+      if (maxAbs >= minAbs && maxAbs < minBoundaryAbs) {
+        max = minBoundaryAbs;
+      }
+      if (minAbs >= maxAbs && minAbs < minBoundaryAbs) {
+        min = -minBoundaryAbs;
+      }
       if(min < 0 && max === 0) {
         max = -1;
       }


### PR DESCRIPTION
Fixed display of data with low maximum absolute value (0.1 and less). 
Instead of breaking on such data, for example, zero-filled array:
![image](https://user-images.githubusercontent.com/3973885/42291157-af84c894-7fd2-11e8-8da8-cbffd112f6b8.png)
we can now get it beautiful:
![image](https://user-images.githubusercontent.com/3973885/42291035-d4494714-7fd1-11e8-9553-e2e311945e24.png).
I extended display boundaries using numbers based on calculation logic of prettyDomain function.